### PR TITLE
docs: update README, WORKLOG, and ARCHITECTURE

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -7,6 +7,8 @@ flowchart TB
         HTML["index.html"]
         Main["src/main.jsx<br/>React entry point"]
         App["src/App.jsx<br/>Root component"]
+        SpeedInsights["@vercel/speed-insights<br/>Core Web Vitals"]
+        VercelAnalytics["@vercel/analytics<br/>Page views & events"]
         
         subgraph Components["React Components"]
             Header["src/components/Header.jsx<br/>Title bar + New Chat button"]
@@ -53,9 +55,9 @@ flowchart TB
         PDFs["pdf-sources/<br/>5 source PDFs"]
     end
 
-    subgraph Tests["Test Suite (46 tests)"]
+    subgraph Tests["Test Suite (48 tests)"]
         T1["chatService.test.js · 8"]
-        T2["payloadBuilder.test.js · 11"]
+        T2["payloadBuilder.test.js · 13"]
         T3["rateLimiter.test.js · 8"]
         T4["chat.test.js · 7"]
         T5["api.test.js · 4"]
@@ -63,6 +65,8 @@ flowchart TB
     end
 
     HTML --> Main --> App
+    App --> SpeedInsights
+    App --> VercelAnalytics
     App --> Hook
     App --> Header
     App --> ChatWindow

--- a/README.md
+++ b/README.md
@@ -23,12 +23,13 @@ When rules conflict, higher-priority sources take precedence.
 - **Frontend:** React 18 + Vite, PWA with offline support
 - **AI:** OpenAI API (gpt-5.4-nano, 400k context window)
 - **Hosting:** Vercel (serverless functions + static site)
-- **Testing:** Vitest with 46 tests across 6 test files
+- **Observability:** Vercel Speed Insights + Vercel Analytics
+- **Testing:** Vitest with 48 tests across 6 test files
 
 ## Project Structure
 
 ```
-court-rules/
+procourtrules/
 ├── api/
 │   ├── chat.js              # Vercel serverless endpoint
 │   └── chat.test.js         # API endpoint tests
@@ -67,8 +68,8 @@ court-rules/
 ### Setup
 
 ```bash
-git clone https://github.com/celticpidge/court-rules.git
-cd court-rules
+git clone https://github.com/celticpidge/procourtrules.git
+cd procourtrules
 npm install
 ```
 

--- a/WORKLOG.md
+++ b/WORKLOG.md
@@ -83,7 +83,7 @@ Each loop followed red-green-refactor: write failing tests first, implement to p
 - Added `.env` and `.env.local` to `.gitignore`
 - Post-cleanup: Vercel build broke with permission error 126 (filter-branch corrupted file modes) — fixed by adding `chmod +x node_modules/.bin/*` to `vercel.json` buildCommand
 
-### Phase 5: Multi-Source Rule Expansion (In Progress)
+### Phase 5: Multi-Source Rule Expansion
 
 **Goal**: Expand from 1 rule source to 5, with a priority hierarchy for conflict resolution.
 
@@ -106,13 +106,16 @@ Each loop followed red-green-refactor: write failing tests first, implement to p
    - `friend-at-court.json` (87,482 words)
    - `itf-rules.json` (14,368 words)
 4. Upgraded model from `gpt-4o-mini` (128k context) to `gpt-5.4-nano` (400k context) — all ~214k tokens of source material fits comfortably
+5. Updated `payloadBuilder.js` to load all 5 sources with priority hierarchy and hierarchy reasoning instructions in the system prompt
+6. Updated `api/chat.js` to load multi-source data
+7. Updated tests — payloadBuilder tests expanded from 11 to 13
 
-**Remaining steps:**
-- Update `payloadBuilder.js` to load all 5 sources with priority hierarchy
-- Update system prompt with hierarchy reasoning instructions
-- Update `api/chat.js` to load multi-source data
-- Update tests
-- Deploy and test with multi-source questions
+### Phase 6: Rename & Observability
+
+- **Renamed** application from `court-rules` to `procourtrules` across package.json, manifest, and GitHub repo
+- **Fixed `.gitignore` encoding** — `pdf-sources/` entry had been written in UTF-16LE causing NUL bytes; rewrote as clean UTF-8
+- **Added Vercel Speed Insights** (`@vercel/speed-insights`) — `<SpeedInsights />` component in `App.jsx` for Core Web Vitals reporting
+- **Added Vercel Analytics** (`@vercel/analytics`) — `<Analytics />` component in `App.jsx` for page view and event tracking
 
 ---
 
@@ -123,7 +126,7 @@ Each loop followed red-green-refactor: write failing tests first, implement to p
 |---|---|
 | `index.html` | HTML shell with PWA meta tags, loads React app |
 | `src/main.jsx` | React root render with StrictMode |
-| `src/App.jsx` | Root component wiring `useChat` hook to `Header` and `ChatWindow` |
+| `src/App.jsx` | Root component wiring `useChat` hook to `Header` and `ChatWindow`, includes Vercel Speed Insights and Analytics |
 
 ### Services (Business Logic)
 | File | Purpose |
@@ -182,13 +185,13 @@ Each loop followed red-green-refactor: write failing tests first, implement to p
 | File | Tests |
 |---|---|
 | `src/services/chatService.test.js` | 8 tests — message management, validation, immutability |
-| `src/services/payloadBuilder.test.js` | 11 tests — payload structure, model, temperature, system prompt content |
+| `src/services/payloadBuilder.test.js` | 13 tests — payload structure, model, temperature, system prompt content |
 | `src/services/rateLimiter.test.js` | 8 tests — allow/block, window expiry, independent tracking |
 | `api/chat.test.js` | 7 tests — validation, rate limiting, OpenAI integration, error handling |
 | `src/utils/api.test.js` | 4 tests — fetch wrapper, HTTP errors, network failures |
 | `src/hooks/useChat.test.js` | 8 tests — hook state management, API calls, error handling, reset |
 
-**Total: 46 tests, all passing**
+**Total: 48 tests, all passing**
 
 ---
 
@@ -200,5 +203,6 @@ Each loop followed red-green-refactor: write failing tests first, implement to p
 | Testing | Vitest 4.1.2, @testing-library/react, jsdom |
 | AI | OpenAI API (gpt-5.4-nano, 400k context window) |
 | Hosting | Vercel (free tier, serverless functions) |
-| VCS | Git, GitHub (celticpidge/court-rules) |
+| VCS | Git, GitHub (celticpidge/procourtrules) |
+| Observability | Vercel Speed Insights, Vercel Analytics |
 | PDF Processing | pdf-parse 2.4.5 (dev tooling only) |


### PR DESCRIPTION
- Updated repo name references from court-rules to procourtrules
- Added Vercel Speed Insights and Analytics to tech stack and architecture diagram
- Updated test counts (46 → 48, payloadBuilder 11 → 13)
- Marked Phase 5 (multi-source) as complete in WORKLOG
- Added Phase 6 (rename & observability) to WORKLOG
- Added Observability row to technology stack table