### PR TITLE
fix: security hardening and error handling improvements

### DIFF
--- a/api/chat.js
+++ b/api/chat.js
@@ -63,7 +63,19 @@ export async function handleChatRequest(req, res) {
     return res.status(400).json({ error: 'Request must include a non-empty messages array.' });
   }
 
-  const ip = req.headers['x-forwarded-for'] || 'unknown';
+  // Only allow user/assistant roles — block injected system messages
+  const sanitizedMessages = messages.filter(
+    (m) => m.role === 'user' || m.role === 'assistant'
+  );
+
+  if (sanitizedMessages.length === 0) {
+    return res.status(400).json({ error: 'Request must include a non-empty messages array.' });
+  }
+
+  // Cap conversation history to limit token usage (5 exchanges)
+  const cappedMessages = sanitizedMessages.slice(-10);
+
+  const ip = req.headers['x-real-ip'] || req.headers['x-forwarded-for'] || 'unknown';
   const bypassKey = req.headers['x-api-key'];
   const validBypass = process.env.RATE_LIMIT_BYPASS_KEY && bypassKey === process.env.RATE_LIMIT_BYPASS_KEY;
 
@@ -78,11 +90,10 @@ export async function handleChatRequest(req, res) {
     }
   }
 
-  const payload = useRag
-    ? await buildRagRequest(messages)
-    : buildChatPayload(messages, sources);
-
   try {
+    const payload = useRag
+      ? await buildRagRequest(cappedMessages)
+      : buildChatPayload(cappedMessages, sources);
     const response = await fetch('https://api.openai.com/v1/chat/completions', {
       method: 'POST',
       headers: {
@@ -99,7 +110,12 @@ export async function handleChatRequest(req, res) {
     }
 
     const data = await response.json();
-    const assistantMessage = data.choices[0].message.content;
+    const choice = data.choices?.[0];
+    if (!choice?.message?.content) {
+      console.error('OpenAI returned no content', JSON.stringify(data).substring(0, 500));
+      return res.status(502).json({ error: 'AI service returned an empty response.' });
+    }
+    const assistantMessage = choice.message.content;
 
     return res.status(200).json({
       message: assistantMessage,

--- a/src/components/SourcesModal.jsx
+++ b/src/components/SourcesModal.jsx
@@ -40,6 +40,7 @@ export default function SourcesModal({ onClose }) {
   const [submitted, setSubmitted] = useState(false);
   const [submitting, setSubmitting] = useState(false);
   const [showSuggest, setShowSuggest] = useState(false);
+  const [error, setError] = useState(null);
 
   useEffect(() => {
     function handleKey(e) {
@@ -53,6 +54,7 @@ export default function SourcesModal({ onClose }) {
     e.preventDefault();
     if (!suggestion.trim()) return;
     setSubmitting(true);
+    setError(null);
     try {
       await sendFeedback({
         rating: 'source-suggestion',
@@ -62,7 +64,7 @@ export default function SourcesModal({ onClose }) {
       });
       setSubmitted(true);
     } catch {
-      // silently fail
+      setError('Failed to submit. Please try again.');
     } finally {
       setSubmitting(false);
     }
@@ -119,6 +121,7 @@ export default function SourcesModal({ onClose }) {
                 maxLength={200}
                 className="feedback-email"
               />
+              {error && <div className="feedback-error">{error}</div>}
               <button type="submit" className="feedback-submit" disabled={submitting || !suggestion.trim()}>
                 {submitting ? 'Sending...' : 'Submit'}
               </button>

--- a/src/hooks/useChat.js
+++ b/src/hooks/useChat.js
@@ -5,10 +5,14 @@ import cachedAnswers from '../data/cachedAnswers.json';
 const DAILY_LIMIT = 50;
 
 function getQuestionCount() {
-  const match = document.cookie.match(/(?:^|; )pcr_count=([^;]+)/);
-  const countData = match ? JSON.parse(atob(match[1])) : null;
-  const today = new Date().toISOString().slice(0, 10);
-  if (countData && countData.d === today) return countData.n;
+  try {
+    const match = document.cookie.match(/(?:^|; )pcr_count=([^;]+)/);
+    const countData = match ? JSON.parse(atob(match[1])) : null;
+    const today = new Date().toISOString().slice(0, 10);
+    if (countData && countData.d === today) return countData.n;
+  } catch {
+    // Corrupt or tampered cookie — treat as fresh
+  }
   return 0;
 }
 

--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -10,7 +10,15 @@ export async function sendMessage(messages) {
     throw new Error('Connection failed. Please check your network and try again.');
   }
 
-  const data = await response.json();
+  let data;
+  try {
+    data = await response.json();
+  } catch {
+    if (!response.ok) {
+      throw new Error('Server error. Please try again later.');
+    }
+    throw new Error('Unexpected response from server.');
+  }
 
   if (!response.ok) {
     throw new Error(data.error || 'Something went wrong.');


### PR DESCRIPTION
- Move buildRagRequest inside try/catch to prevent unhandled crashes
- Add try/catch around cookie parsing to handle tampered cookies
- Filter message roles to user/assistant only (block prompt injection)
- Cap conversation history to 10 messages (limit token cost)
- Show error state in SourcesModal suggestion form
- Use x-real-ip header for rate limiting (not spoofable)
- Guard data.choices[0] for empty OpenAI responses
- Handle non-JSON server error responses in sendMessage